### PR TITLE
Parameter for bucket region when deploying in non us-east-1 region

### DIFF
--- a/SubTemplates/IoT/Lambdas/bootstrap_generator/app.py
+++ b/SubTemplates/IoT/Lambdas/bootstrap_generator/app.py
@@ -13,13 +13,14 @@ endpoint = boto3.client('iot-data')
 s3Client = boto3.client('s3')
 
 resourceTag = os.environ['ResourceTag']
+region = os.environ['Region']
 
 bootstrapPolicyName = '{}_birth_policy'.format(resourceTag)
 BUCKET_NAME = '{}-per-vendor-bootstraps'.format(resourceTag)
 rootCertUrl = "https://www.amazontrust.com/repository/AmazonRootCA1.pem"
 rootCert = urlopen(rootCertUrl)
 
-s3Client.create_bucket(Bucket=BUCKET_NAME)
+s3Client.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration={'LocationConstraint': region})
 
 def handler(event, context):
     

--- a/SubTemplates/IoT/Lambdas/provision_device/app.py
+++ b/SubTemplates/IoT/Lambdas/provision_device/app.py
@@ -202,7 +202,7 @@ def createModelBootstraps():
     model_bucket = '{}-per-vendor-bootstraps'.format(resourceTag)
     
     with open('artifacts/models.txt', 'r') as rows:
-        s3Client.create_bucket(Bucket=model_bucket)
+        s3Client.create_bucket(Bucket=model_bucket, CreateBucketConfiguration={'LocationConstraint': region})
         models = rows.read().splitlines()
         rootCert = urlopen(rootCertUrl)
         

--- a/SubTemplates/IoT/template.yaml
+++ b/SubTemplates/IoT/template.yaml
@@ -160,6 +160,9 @@ Resources:
       Handler: app.handler
       Timeout: 360
       MemorySize: 3008
+      Environment:
+        Variables:
+          Region: !Ref AWS::Region
       Policies:
         - AWSLambdaBasicExecutionRole
         - Version: "2012-10-17"


### PR DESCRIPTION


*Issue #, if available:* Stack creation fails in non us-east-1 as create_bucket needs the region name.

*Description of changes:* Added the region parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
